### PR TITLE
Fix Mobbin search query formatting

### DIFF
--- a/mobbin_client.py
+++ b/mobbin_client.py
@@ -109,7 +109,8 @@ class MobbinClient:
         # wfts 会自动处理空格，并将它们解释为 AND 连接符，但为了明确，我们手动替换。
         # 例如，搜索 "time schedule" 会被转换为 "time & schedule"，
         # 这意味着会查找同时包含 "time" 和 "schedule" 的应用。
-        processed_query = query.replace(' ', '&')
+        # Use " & " between terms so Supabase interprets it as a logical AND
+        processed_query = " & ".join(query.split())
         params = {
             "select": "*",
             "platform": f"eq.{platform}",


### PR DESCRIPTION
## Summary
- join tokens with ` & ` in `search_apps` to build valid full-text query

## Testing
- `python -m py_compile mobbin_client.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a146c8fccc8324b35e2afbc73a21ae